### PR TITLE
Implement basic session utilities

### DIFF
--- a/sessions/feedback.py
+++ b/sessions/feedback.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from ai.trainer import DQNTrainer
+
+
+def evaluate(trainer: DQNTrainer, games: int = 5) -> float:
+    """Return the average reward of ``trainer`` over ``games`` games."""
+    return trainer._evaluate(games)
+
+
+def log_score(save_dir: str, step: int, value: float) -> None:
+    """Append ``step`` and evaluation ``value`` to ``feedback.csv`` in ``save_dir``."""
+    path = Path(save_dir) / "feedback.csv"
+    write_header = not path.exists()
+    with path.open("a", newline="") as f:
+        writer = csv.writer(f)
+        if write_header:
+            writer.writerow(["step", "value"])
+        writer.writerow([step, value])

--- a/sessions/runner.py
+++ b/sessions/runner.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from ai.trainer import DQNTrainer
+
+
+class SessionRunner:
+    """Thin wrapper around :class:`DQNTrainer`."""
+
+    def __init__(self, save_dir: str = "models", seed: int | None = None) -> None:
+        self.trainer = DQNTrainer(save_dir=save_dir, seed=seed)
+        self._running = False
+
+    def start(self, steps: int = 100_000) -> None:
+        """Start a training session for ``steps`` environment steps."""
+        if self._running:
+            raise RuntimeError("Session already running")
+        self._running = True
+        try:
+            self.trainer.train(total_steps=steps)
+        finally:
+            self._running = False
+
+    def stop(self) -> None:
+        """Mark the session as stopped. (No mid‑episode interrupt.)"""
+        self._running = False


### PR DESCRIPTION
## Summary
- add a simple `SessionRunner` wrapper to start training
- add `evaluate` and `log_score` helpers for feedback

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b10b4be288321b278a07a9b7b1ddd