### PR TITLE
Annotate agent methods with explicit types

### DIFF
--- a/ai/agent.py
+++ b/ai/agent.py
@@ -7,6 +7,9 @@ rotation for the active piece.
 """
 
 import numpy as np
+from typing import Tuple
+
+from engine.piece import Piece
 
 class BaseAgent:
     """Abstract interface for Tetris agents."""
@@ -15,10 +18,15 @@ class BaseAgent:
         """Initialise the agent."""
         pass
 
-    def choose_action(self, board_state, piece, piece_x, piece_y, piece_rotation):
-        """
-        Should return a tuple (target_x, target_rotation) for the active piece.
-        """
+    def choose_action(
+        self,
+        board_state: np.ndarray,
+        piece: Piece,
+        piece_x: int,
+        piece_y: int,
+        piece_rotation: int,
+    ) -> Tuple[int, int]:
+        """Should return ``(target_x, target_rotation)`` for the active piece."""
         raise NotImplementedError
 
 
@@ -29,7 +37,7 @@ class HeuristicAgent(BaseAgent):
         """Initialise the heuristic agent."""
         super().__init__()
 
-    def evaluate_board(self, board):
+    def evaluate_board(self, board: np.ndarray) -> float:
         """Basic heuristics: lower total height and more cleared lines are better"""
         heights = board.shape[0] - np.argmax(board[::-1], axis=0)
         heights[np.all(board == 0, axis=0)] = 0
@@ -38,10 +46,15 @@ class HeuristicAgent(BaseAgent):
         bumpiness = np.sum(np.abs(np.diff(heights)))
         return -0.5 * aggregate_height - 0.7 * holes - 0.3 * bumpiness
 
-    def choose_action(self, board_state, piece, piece_x, piece_y, piece_rotation):
-        """
-        Brute-force simulation of all placements. Chooses the best-scoring one.
-        """
+    def choose_action(
+        self,
+        board_state: np.ndarray,
+        piece: Piece,
+        piece_x: int,
+        piece_y: int,
+        piece_rotation: int,
+    ) -> Tuple[int, int]:
+        """Brute-force simulation of all placements. Chooses the best-scoring one."""
         from engine.core import TetrisBoard
 
         best_score = float('-inf')


### PR DESCRIPTION
## Summary
- add Tuple and Piece imports for type usage
- type annotate BaseAgent and HeuristicAgent methods
- specify evaluate_board inputs and return types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe8ebf4f0832181c33ba9eae5c0bf